### PR TITLE
Bewertete Version

### DIFF
--- a/ModSim WS1718 Uebung 03.ipynb
+++ b/ModSim WS1718 Uebung 03.ipynb
@@ -223,7 +223,7 @@
    "metadata": {},
    "source": [
     "#### Begründung\n",
-    "Der Wahrheitswert für (1.3-1.0)==0.3 wird als **False** ausgegeben. Der Grund dafür liegt darin, dass die gleiche Zahl (wie 0.3) auf verschiedene Weisen binär dargestellt werden kann. Je größer das Intervall wird, aus dem die dargestellten Zahlen kommen, desto ungenauer werden die Beträge dieser. \n"
+    "Der Wahrheitswert für (1.3-1.0)==0.3 wird als **False** ausgegeben. Der Grund dafür liegt darin, dass die gleiche Zahl (wie 0.3) auf verschiedene Weisen binär dargestellt werden kann. Je größer das Intervall wird, aus dem die dargestellten Zahlen kommen, desto ungenauer werden die Beträge dieser.# \n"
    ]
   },
   {


### PR DESCRIPTION
Af. 3 "die gleiche Zahl (wie 0.3) auf verschiedene Weisen binär dargestellt werden kann" 0.3 wird eigentlich nur auf eine Weise binär dargestellt werden kann, aber die Darstellung ist nicht als genau wie den ursprüngliche Wert 0.3 (-5) "Je größer das Intervall wird, aus dem die dargestellten Zahlen kommen, desto ungenauer werden die Beträge dieser" (?)